### PR TITLE
Replace registry with `packages()` function

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -100,9 +100,7 @@ function(add_zserio_module NAME ROOT ENTRY)
 
   target_compile_definitions(${NAME}-reflection
     PRIVATE
-      REFLECTION_DEFS_INCLUDE="${GEN_SRC_ROOT}/reflection-defs.cpp"
-    PUBLIC
-      ZSR_GENERATE_LOAD_STUB=1)
+      REFLECTION_DEFS_INCLUDE="${GEN_SRC_ROOT}/reflection-defs.cpp")
 
   target_compile_options(${NAME}-reflection
     PRIVATE

--- a/runtime/src/lib-prefix.cpp
+++ b/runtime/src/lib-prefix.cpp
@@ -38,6 +38,12 @@ struct meta_for_compound;
 
 #include "reflection-macros.hpp"
 
+static std::vector<const zsr::Package*>& lpackages()
+{
+    static std::vector<const zsr::Package*> packages;
+    return packages;
+}
+
 /* -- Generated Source Begins Here -- */
 #ifdef REFLECTION_DEFS_INCLUDE
 #    include REFLECTION_DEFS_INCLUDE
@@ -45,9 +51,12 @@ struct meta_for_compound;
 #    error "Missing definition of 'REFLECTION_DEFS_INCLUDE'!"
 #endif
 
-/* Generate optional load stub */
-#ifdef ZSR_GENERATE_LOAD_STUB
-namespace zsr {
-void loadStub() {}
+namespace zsr
+{
+
+const std::vector<const Package*>& packages ()
+{
+    return lpackages();
 }
-#endif
+
+}

--- a/runtime/src/reflection-macros.hpp
+++ b/runtime/src/reflection-macros.hpp
@@ -56,14 +56,12 @@
  */
 
 #define ZSERIO_REFLECT_PACKAGE_BEGIN(NAME, NS)      \
-    namespace NS {}                                 \
-                                                    \
     struct init__ ## NAME {                         \
         init__ ## NAME () {                         \
             namespace PkgNamespace = :: NS;         \
                                                     \
             static zsr::Package p;                  \
-            zsr::registry().packages.push_back(&p); \
+            lpackages().push_back(&p);              \
                                                     \
             p.ident = #NAME;
 

--- a/runtime/src/types.cpp
+++ b/runtime/src/types.cpp
@@ -1,10 +1,1 @@
 #include "zsr/types.hpp"
-
-namespace zsr {
-
-Registry& registry() {
-    static Registry reg;
-    return reg;
-}
-
-}

--- a/runtime/test/zserio/base.hpp
+++ b/runtime/test/zserio/base.hpp
@@ -7,11 +7,8 @@
 #include "zsr/find.hpp"
 #include "zsr/stub.hpp"
 
-#define PKG                                         \
-    static auto* pkg = [] {                         \
-        zsr::loadStub();                            \
-        return zsr::registry().packages.front();    \
-    }()
+#define PKG                                     \
+    static auto* pkg = zsr::packages().front();
 
 template <class _Type>
 ::testing::AssertionResult AssertVariantEq(const char* expr1,

--- a/runtime/zsr/stub.hpp
+++ b/runtime/zsr/stub.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <vector>
+
 namespace zsr {
 
-#ifdef ZSR_GENERATE_LOAD_STUB
-void loadStub();
-#endif
+struct Package;
+
+const std::vector<const Package*>& packages();
 
 }

--- a/runtime/zsr/types.hpp
+++ b/runtime/zsr/types.hpp
@@ -275,14 +275,4 @@ struct Package
     std::vector<const Compound*> compounds;
 };
 
-/**
- * Metadata registry
- */
-struct Registry
-{
-    std::vector<const Package*> packages;
-};
-
-Registry& registry();
-
 } // namespace zsr


### PR DESCRIPTION
This also replaces the empty stub-function to trigger
linking the translation-unit.