### PR TITLE
Run zserio-codegen at compiletime

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,25 +21,23 @@ jobs:
         java-version: 1.8
     - name: Setup
       run: |
-        mkdir build-extension
-        mkdir build-runtime
+        mkdir build
     - name: Clone zserio
       run: |
         git clone https://github.com/ndsev/zserio.git zserio
-    - name: Configure extension
-      working-directory: build-extension
-      run: |
-        cmake ../extension
-    - name: Configure runtime
-      working-directory: build-runtime
-      run: |
-        cmake -DZSERIO_JAR_PATH=../build-extension/zserio.jar -DZSERIO_RT_DIR=../zserio/compiler/extensions/cpp/runtime/src ../runtime
+    - name: Configure
+      working-directory: build
+      run: >
+        cmake
+        -DCMAKE_BUILD_TYPE=Debug
+        -DZSERIO_RT_DIR=../zserio/compiler/extensions/cpp/runtime/src
+        ..
     - name: Build runtime
-      working-directory: build-runtime
+      working-directory: build
       run: |
         cmake --build .
     - name: Run CTest
-      working-directory: build-runtime
+      working-directory: build
       run: |
         ctest --verbose
   build-windows:
@@ -56,32 +54,25 @@ jobs:
         java-version: 1.8
     - name: Setup
       run: |
-        mkdir build-extension
-        mkdir build-runtime
+        mkdir build
     - name: Clone zserio
       run: |
         git clone https://github.com/ndsev/zserio.git zserio
-    - name: Configure extension
-      working-directory: build-extension
-      run: |
-        cmake ../extension
-      shell: cmd
-    - name: Configure runtime
-      working-directory: build-runtime
+    - name: Configure
+      working-directory: build
       run: >
         cmake
         -DCMAKE_BUILD_TYPE=Debug
-        -DZSERIO_JAR_PATH=../build-extension/zserio.jar
         -DZSERIO_RT_DIR=../zserio/compiler/extensions/cpp/runtime/src
-        ../runtime
+        ..
       shell: cmd
     - name: Build runtime
-      working-directory: build-runtime
+      working-directory: build
       run: |
         cmake --build .
       shell: cmd
     - name: Run CTest
-      working-directory: build-runtime
+      working-directory: build
       run: |
         ctest -C Debug --verbose
       shell: cmd

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,7 +10,6 @@ jobs:
   build-linux:
     name: Linux
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
       with:
@@ -40,10 +39,10 @@ jobs:
       working-directory: build
       run: |
         ctest --verbose
+
   build-windows:
     name: Windows
     runs-on: windows-latest
-
     steps:
     - uses: actions/checkout@v2
       with:
@@ -76,3 +75,38 @@ jobs:
       run: |
         ctest -C Debug --verbose
       shell: cmd
+
+  build-macos:
+    name: MacOS
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Setup
+      run: |
+        mkdir build
+        brew install ant
+    - name: Clone zserio
+      run: |
+        git clone https://github.com/ndsev/zserio.git zserio
+    - name: Configure
+      working-directory: build
+      run: >
+        cmake
+        -DCMAKE_BUILD_TYPE=Debug
+        -DCMAKE_CXX_STANDARD=11
+        -DZSERIO_RT_DIR=../zserio/compiler/extensions/cpp/runtime/src
+        ..
+    - name: Build runtime
+      working-directory: build
+      run: |
+        cmake --build .
+    - name: Run CTest
+      working-directory: build
+      run: |
+        ctest -C Debug --verbose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(zserio-cpp-introspection)
+
+enable_testing()
+
+add_subdirectory(extension)
+add_subdirectory(runtime)

--- a/README
+++ b/README
@@ -12,35 +12,14 @@
      Z S E R I O  C + +  R E F L E C T I O N
 
 
-Extension
-=========
-
 Build
------
+=====
 
->   cd extension
->   ant install
-
-Runtime
-=======
-
-Build
------
-
->   cd runtime
->   mkdir build && cd build
->   cmake -DZSERIO_RT_DIR=<path-to-zserio-cpp-rt-dir> \
->         -DZSERIO_JAR_PATH=<path-to-zserio-jar> ..
->
->   cmake --build .
+> mkdir build && cd build
+> cmake -DZSERIO_RT_DIR=<path-to-zserio-cpp-rt-dir> ..
+> cmake --build .
 
 Test
-----
+====
 
->   ctest --verbose
-
-Hacking
--------
-
-- Use the ./format script to apply cmake-format on all sources.
-- Sources under /zsr are public, sources under /src are private.
+> ctest --verbose

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -6,6 +6,16 @@ if (NOT ANT_PATH)
   message(FATAL_ERROR "Could not find ant binary!")
 endif()
 
+set(JAR_PATH "${CMAKE_CURRENT_BINARY_DIR}/zserio.jar")
+
 execute_process(
   COMMAND ${ANT_PATH} install "-Dzserio_cpp_reflect.install_dir=${CMAKE_CURRENT_BINARY_DIR}"
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+
+add_custom_target(zserio
+  DEPENDS "${JAR_PATH}"
+  COMMENT "Download and compile zserio C++ introspection extension.")
+
+set_target_properties(zserio
+  PROPERTIES
+    jar "${JAR_PATH}")

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,52 +1,27 @@
 cmake_minimum_required(VERSION 3.10.2)
-project(zsr)
+project(zserio-cpp-introspection-runtime)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set(gtest_force_shared_crt ON CACHE BOOL "Always use msvcrt.dll")
 
-set(TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test")
-set(SRC "${CMAKE_CURRENT_SOURCE_DIR}")
+set(SRC  "${CMAKE_CURRENT_SOURCE_DIR}")
+set(TEST "${SRC}/test")
 
 if (NOT MSVC)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON) # This does not set -fPIC :(
   set(CMAKE_CXX_FLAGS -fPIC)
 endif()
 
-## ZSerio binary
+## ZSERIO C++ runtime (optional)
 ####
 
-option(ZSERIO_JAR_PATH "Path to zserio jar.")
-if (ZSERIO_JAR_PATH)
-  find_program(JAVA java)
-  if (NOT JAVA)
-    message(FATAL_ERROR "Could not find java!")
+if (NOT TARGET ZserioCppRuntime)
+  option(ZSERIO_RT_DIR "Directory of zserio C++ runtime CMakeLists.txt (e.g. extensions/cpp/runtime/src)")
+  if (ZSERIO_RT_DIR)
+    add_subdirectory("${ZSERIO_RT_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/zserio-cpp-rt")
+  else ()
+    message(FATAL_ERROR "Option ZSERIO_RT_DIR is empty.")
   endif()
-
-  set(ZSERIO ${JAVA})
-  list(APPEND ZSERIO "-jar")
-  list(APPEND ZSERIO "${ZSERIO_JAR_PATH}")
-
-  # File used as dependency for generating sources
-  set(ZSERIO_GENERATOR_DEP "${ZSERIO_JAR_PATH}")
-else()
-  find_program(ZSERIO zserio)
-  if (NOT ZSERIO)
-    message(FATAL_ERROR
-      "Could not find zserio binary! "
-      "Add zserio to PATH or set ZSERIO_JAR_PATH to the zserio jar.")
-  endif()
-
-  set(ZSERIO_GENERATOR_DEP "${ZSERIO}")
-endif()
-
-## ZSERIO C++ runtime
-####
-
-option(ZSERIO_RT_DIR "Directory of zserio C++ runtime CMakeLists.txt (e.g. extensions/cpp/runtime/src)")
-if (ZSERIO_RT_DIR)
-  add_subdirectory("${ZSERIO_RT_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/zserio-cpp-rt")
-else ()
-  message(FATAL_ERROR "Option ZSERIO_RT_DIR is empty.")
 endif()
 
 ## ZSR Runtime
@@ -62,18 +37,44 @@ target_compile_features(zsr
 
 target_include_directories(zsr
   PUBLIC
-    "${CMAKE_CURRENT_SOURCE_DIR}")
+    "${SRC}")
 
 target_link_libraries(zsr
   PUBLIC
     ZserioCppRuntime)
 
+set_target_properties(zsr
+  PROPERTIES
+    src_dir "${CMAKE_CURRENT_SOURCE_DIR}")
+
+add_custom_target(zsr-amalgamate
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/amalgamate.cmake")
+
+set_target_properties(zsr-amalgamate
+  PROPERTIES
+    src "${CMAKE_CURRENT_SOURCE_DIR}/amalgamate.cmake")
+
 function(add_zserio_module NAME ROOT ENTRY)
   set(GEN_SRC_ROOT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}.zserio-gen/")
   file(MAKE_DIRECTORY "${GEN_SRC_ROOT}")
 
+  find_program(JAVA java)
+  if (NOT JAVA)
+    message(FATAL_ERROR "Could not find java!")
+  endif()
+
+  set(ZSERIO ${JAVA})
+
+  get_target_property(JAR_PATH zserio jar)
+  if (${JAR_PATH} EQUAL "NOTFOUND")
+    message(FATAL_ERROR "Could not read property 'jar' from target 'zserio'.")
+  endif()
+
+  list(APPEND ZSERIO "-jar")
+  list(APPEND ZSERIO "${JAR_PATH}")
+
   add_custom_command(
-    DEPENDS "${ZSERIO_GENERATOR_DEP}"
+    DEPENDS zserio
     OUTPUT "${GEN_SRC_ROOT}/reflection-defs.cpp"
     COMMAND ${ZSERIO} -setTopLevelPackage ${ZSERIO_TLP}
                       -cpp ${GEN_SRC_ROOT}
@@ -81,10 +82,13 @@ function(add_zserio_module NAME ROOT ENTRY)
                       -src ${ROOT}
                       ${ENTRY})
 
+  # Generated source amalgamation
+  get_target_property(AMALGAMATE zsr-amalgamate src)
+
   add_custom_command(
     DEPENDS "${GEN_SRC_ROOT}/reflection-defs.cpp"
     OUTPUT "${GEN_SRC_ROOT}/amalgamation.cpp"
-    COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_SOURCE_DIR}/amalgamate.cmake"
+    COMMAND ${CMAKE_COMMAND} -P "${AMALGAMATE}"
                                 "${GEN_SRC_ROOT}/${ZSERIO_TLP}"
                                 "${GEN_SRC_ROOT}/amalgamation.cpp")
 
@@ -97,9 +101,12 @@ function(add_zserio_module NAME ROOT ENTRY)
   target_link_libraries(${NAME}
     PUBLIC ZserioCppRuntime)
 
+  # Reflection runtime lib
+  get_target_property(ZSR_SRC zsr src_dir)
+
   add_library(${NAME}-reflection SHARED
-    "${SRC}/zsr/stub.hpp"
-    "${SRC}/src/lib-prefix.cpp")
+    "${ZSR_SRC}/zsr/stub.hpp"
+    "${ZSR_SRC}/src/lib-prefix.cpp")
 
   target_compile_definitions(${NAME}-reflection
     PRIVATE
@@ -112,7 +119,7 @@ function(add_zserio_module NAME ROOT ENTRY)
 
   target_include_directories(${NAME}-reflection
     PRIVATE
-      "${SRC}/src")
+      "${ZSR_SRC}/src")
 
   target_link_libraries(${NAME}-reflection
     zsr
@@ -127,7 +134,7 @@ function(add_zsr_test TARGET FILE)
     "${FILE}")
 
   target_include_directories(${TARGET}
-    PRIVATE "${SRC}" "${TEST_SRC}/zserio")
+    PRIVATE "${TEST}/zserio")
 
   target_link_libraries(${TARGET}
     PRIVATE zsr gtest gtest_main)
@@ -145,8 +152,8 @@ function(add_zsr_test TARGET FILE)
 endfunction()
 
 function(add_zsr_module_test NAME)
-  add_zserio_module(zs-${NAME} "${TEST_SRC}/zserio/${NAME}" "${NAME}.zs")
-  add_zsr_test(${NAME} "${TEST_SRC}/zserio/${NAME}/${NAME}.cpp")
+  add_zserio_module(zs-${NAME} "${TEST}/zserio/${NAME}" "${NAME}.zs")
+  add_zsr_test(${NAME} "${TEST}/zserio/${NAME}/${NAME}.cpp")
 
   target_link_libraries(${NAME}
     PRIVATE zs-${NAME} zs-${NAME}-reflection)
@@ -163,7 +170,7 @@ if (ZSR_ENABLE_TESTING)
 
   set(ZSERIO_TLP "zsr")
 
-  add_zsr_test(variant-test "${TEST_SRC}/variant-test.cpp")
+  add_zsr_test(variant-test "${TEST}/variant-test.cpp")
 
   add_zsr_module_test(bitmask_test)
   add_zsr_module_test(choice_test)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -14,8 +14,8 @@ endif()
 
 ## ZSerio binary
 ####
-option(ZSERIO_JAR_PATH "Path to zserio jar.")
 
+option(ZSERIO_JAR_PATH "Path to zserio jar.")
 if (ZSERIO_JAR_PATH)
   find_program(JAVA java)
   if (NOT JAVA)
@@ -25,6 +25,9 @@ if (ZSERIO_JAR_PATH)
   set(ZSERIO ${JAVA})
   list(APPEND ZSERIO "-jar")
   list(APPEND ZSERIO "${ZSERIO_JAR_PATH}")
+
+  # File used as dependency for generating sources
+  set(ZSERIO_GENERATOR_DEP "${ZSERIO_JAR_PATH}")
 else()
   find_program(ZSERIO zserio)
   if (NOT ZSERIO)
@@ -32,6 +35,8 @@ else()
       "Could not find zserio binary! "
       "Add zserio to PATH or set ZSERIO_JAR_PATH to the zserio jar.")
   endif()
+
+  set(ZSERIO_GENERATOR_DEP "${ZSERIO}")
 endif()
 
 ## ZSERIO C++ runtime
@@ -63,50 +68,34 @@ target_link_libraries(zsr
   PUBLIC
     ZserioCppRuntime)
 
-set(ZSERIO_TLP "nds") # Zserio top-level-package
-
 function(add_zserio_module NAME ROOT ENTRY)
   set(GEN_SRC_ROOT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}.zserio-gen/")
-
   file(MAKE_DIRECTORY "${GEN_SRC_ROOT}")
 
-  execute_process(
+  add_custom_command(
+    DEPENDS "${ZSERIO_GENERATOR_DEP}"
+    OUTPUT "${GEN_SRC_ROOT}/reflection-defs.cpp"
     COMMAND ${ZSERIO} -setTopLevelPackage ${ZSERIO_TLP}
                       -cpp ${GEN_SRC_ROOT}
                       -cpp_reflect ${GEN_SRC_ROOT}
                       -src ${ROOT}
-                      ${ENTRY}
-    RESULT_VARIABLE ZSERIO_RES
-    ERROR_VARIABLE ZSERIO_STDERR
-    OUTPUT_QUIET)
+                      ${ENTRY})
 
-  if (NOT ZSERIO_RES EQUAL 0)
-    message(FATAL_ERROR "Generating sources failed.\n"
-                        "ZSerio returned: ${ZSERIO_RES}\n"
-                        "Error: ${ZSERIO_ERROR}")
-  endif()
+  add_custom_command(
+    DEPENDS "${GEN_SRC_ROOT}/reflection-defs.cpp"
+    OUTPUT "${GEN_SRC_ROOT}/amalgamation.cpp"
+    COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_SOURCE_DIR}/amalgamate.cmake"
+                                "${GEN_SRC_ROOT}/${ZSERIO_TLP}"
+                                "${GEN_SRC_ROOT}/amalgamation.cpp")
 
-  file(GLOB_RECURSE GEN_SRC
-    "${GEN_SRC_ROOT}/${ZSERIO_TLP}/*.cpp")
+  add_library(${NAME} SHARED
+    "${GEN_SRC_ROOT}/amalgamation.cpp")
 
-  if (GEN_SRC)
-    add_library(${NAME} SHARED
-      ${GEN_SRC})
+  target_include_directories(${NAME}
+    PUBLIC "${GEN_SRC_ROOT}")
 
-    target_include_directories(${NAME}
-      PUBLIC "${GEN_SRC_ROOT}")
-
-    target_link_libraries(${NAME}
-      PUBLIC ZserioCppRuntime)
-  else()
-    add_library(${NAME} INTERFACE)
-
-    target_include_directories(${NAME}
-      INTERFACE "${GEN_SRC_ROOT}")
-
-    target_link_libraries(${NAME}
-      INTERFACE ZserioCppRuntime)
-  endif()
+  target_link_libraries(${NAME}
+    PUBLIC ZserioCppRuntime)
 
   add_library(${NAME}-reflection SHARED
     "${SRC}/zsr/stub.hpp"

--- a/runtime/amalgamate.cmake
+++ b/runtime/amalgamate.cmake
@@ -1,0 +1,24 @@
+function(zsr_amalgamate_sources ROOT TARGET)
+  message("Amalgamating to ${TARGET}...")
+
+  file(WRITE "${TARGET}" "")
+
+  file(GLOB_RECURSE SOURCES
+    "${ROOT}/*.cpp")
+
+  foreach(SRC ${SOURCES})
+    message(STATUS "  ${SRC}")
+
+    file(READ ${SRC} CONTENTS)
+    file(APPEND ${TARGET} "${CONTENTS}")
+  endforeach()
+endfunction()
+
+# Why 5?
+#   cmake -P <script> <3> <4>
+#   0     1  2        3   4
+if (${CMAKE_ARGC} EQUAL 5)
+  zsr_amalgamate_sources("${CMAKE_ARGV3}" "${CMAKE_ARGV4}")
+else()
+  message(FATAL_ERROR "Missing arguments.")
+endif()

--- a/runtime/amalgamate.cmake
+++ b/runtime/amalgamate.cmake
@@ -1,5 +1,6 @@
 function(zsr_amalgamate_sources ROOT TARGET)
-  message("Amalgamating to ${TARGET}...")
+  get_filename_component(TARGET_NAME ${TARGET} NAME)
+  message("Amalgamating generated zserio sources to ${TARGET_NAME}...")
 
   file(WRITE "${TARGET}" "")
 
@@ -7,7 +8,8 @@ function(zsr_amalgamate_sources ROOT TARGET)
     "${ROOT}/*.cpp")
 
   foreach(SRC ${SOURCES})
-    message(STATUS "  ${SRC}")
+    get_filename_component(SRC_NAME ${SRC} NAME)
+    message(STATUS "${SRC_NAME}")
 
     file(READ ${SRC} CONTENTS)
     file(APPEND ${TARGET} "${CONTENTS}")


### PR DESCRIPTION
* Run zserio-codegen at runtime (CMake custom target).
* Do not use cached CMake variables as globals anymore.
* Use CMake target properties for saving informations with targets.
* New top-level CMake which builds zserio + introspection-runtime
* Added CI step to build on macOS