### PR TITLE
Remove enum CType

### DIFF
--- a/runtime/src/c-type-helper.hpp
+++ b/runtime/src/c-type-helper.hpp
@@ -86,9 +86,7 @@ struct CTypeTraits<_Type,
 {
     static auto set(CType& type)
     {
-        type.type = CType::Enum;
-        type.size = sizeof(std::underlying_type_t<_Type>);
-        type.array = false;
+        CTypeTraits<std::underlying_type_t<_Type>>::set(type);
     }
 };
 

--- a/runtime/test/zserio/enumeration_test/enumeration_test.cpp
+++ b/runtime/test/zserio/enumeration_test/enumeration_test.cpp
@@ -33,7 +33,7 @@ TEST(EnumTest, enum_member) {
 
     auto* type = meta_field->type;
     ASSERT_TRUE(type);
-    ASSERT_EQ(type->ctype.type, zsr::CType::Enum);
+    ASSERT_EQ(type->ctype.type, zsr::CType::UInt);
     ASSERT_FALSE(type->ctype.array);
 }
 

--- a/runtime/zsr/types.hpp
+++ b/runtime/zsr/types.hpp
@@ -67,13 +67,12 @@ struct CType
         UInt,
         Int,
         Float,
-        Enum,
         String,
         Structure,
         BitBuffer,
     } type;
 
-    size_t size = 0;    /* Size in bits */
+    size_t size = 0;    /* Size in bytes */
     bool array = false; /* Array (vector) of type */
 };
 


### PR DESCRIPTION
Instead of exposing enums as `Enum`, expose them by their underlying type, which is the type stored in the items variants.