### PR TITLE
Explicitly export symbols

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -54,6 +54,15 @@ set_target_properties(zsr-amalgamate
   PROPERTIES
     src "${CMAKE_CURRENT_SOURCE_DIR}/amalgamate.cmake")
 
+target_compile_definitions(zsr
+  PRIVATE
+    ZSR_BUILD=1)
+
+target_compile_options(zsr
+  PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Werror -fvisibility=hidden>)
+
 function(add_zserio_module ZSR_MODULE_NAME)
   cmake_parse_arguments(PARSE_ARGV 0
     ZSR_MODULE "" "ROOT;ENTRY;TOP_LEVEL_PKG" "")
@@ -127,12 +136,13 @@ function(add_zserio_module ZSR_MODULE_NAME)
 
   target_compile_definitions(${ZSR_MODULE_NAME}-reflection
     PRIVATE
-      REFLECTION_DEFS_INCLUDE="${GEN_SRC_ROOT}/reflection-defs.cpp")
+      REFLECTION_DEFS_INCLUDE="${GEN_SRC_ROOT}/reflection-defs.cpp"
+      ZSR_BUILD=1)
 
   target_compile_options(${ZSR_MODULE_NAME}-reflection
     PRIVATE
       $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
-      $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Werror>)
+      $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Werror -fvisibility=hidden>)
 
   target_include_directories(${ZSR_MODULE_NAME}-reflection
     PRIVATE
@@ -141,9 +151,6 @@ function(add_zserio_module ZSR_MODULE_NAME)
   target_link_libraries(${ZSR_MODULE_NAME}-reflection
     zsr
     ${ZSR_MODULE_NAME})
-
-  set_target_properties(${ZSR_MODULE_NAME}-reflection PROPERTIES
-    WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endfunction()
 
 ## Test

--- a/runtime/zsr/error.hpp
+++ b/runtime/zsr/error.hpp
@@ -1,28 +1,39 @@
 #pragma once
 
+#include "export.hpp"
 #include <exception>
+
+#ifdef _MSC_VER
+/* Disable warning about inheriting from unexported class */
+#pragma warning(push)
+#pragma warning(disable:4275)
+#endif
 
 namespace zsr {
 
 /**
  * Exception base class.
  */
-struct Error : std::exception
+struct ZSR_EXPORT Error : std::exception
 {};
 
-struct ParameterListTypeError : Error
+struct ZSR_EXPORT ParameterListTypeError : Error
 {
     const char* what() const noexcept override;
 };
 
-struct IntrospectableCastError : Error
+struct ZSR_EXPORT IntrospectableCastError : Error
 {
     const char* what() const noexcept override;
 };
 
-struct VariantCastError : Error
+struct ZSR_EXPORT VariantCastError : Error
 {
     const char* what() const noexcept override;
 };
 
 } // namespace zsr
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/runtime/zsr/export.hpp
+++ b/runtime/zsr/export.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#if defined(_MSC_VER)
+    #if defined(ZSR_BUILD)
+        #define ZSR_EXPORT __declspec(dllexport)
+    #else
+        #define ZSR_EXPORT __declspec(dllimport)
+    #endif
+#else
+    #define ZSR_EXPORT __attribute__ ((visibility ("default")))
+#endif

--- a/runtime/zsr/find.hpp
+++ b/runtime/zsr/find.hpp
@@ -6,12 +6,12 @@ namespace zsr {
 namespace impl {
 
 template <class>
-struct child_iter
+struct ZSR_EXPORT child_iter
 {};
 
 #define DECL_ITER(TYPE, PARENT_TYPE, LIST)                                     \
     template <>                                                                \
-    struct child_iter<TYPE>                                                    \
+    struct ZSR_EXPORT child_iter<TYPE>                                         \
     {                                                                          \
         static auto get(const PARENT_TYPE* r)                                  \
         {                                                                      \

--- a/runtime/zsr/introspectable-private.hpp
+++ b/runtime/zsr/introspectable-private.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "zsr/error.hpp"
+#include "error.hpp"
+#include "export.hpp"
 
-#include <assert.h>
+#include <cassert>
 #include <unordered_map>
 #include <vector>
 

--- a/runtime/zsr/introspectable.hpp
+++ b/runtime/zsr/introspectable.hpp
@@ -3,7 +3,13 @@
 #include <any>
 #include <memory>
 
+#include "export.hpp"
 #include "introspectable-private.hpp"
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4251)
+#endif
 
 namespace zsr {
 
@@ -15,7 +21,7 @@ struct Compound;
  *
  * Instanciated by `Compound::alloc`.
  */
-class Introspectable
+class ZSR_EXPORT Introspectable
 {
 public:
     Introspectable(const Compound*, std::shared_ptr<impl::InstanceBase>);
@@ -37,3 +43,7 @@ public:
 };
 
 } // namespace zsr
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/runtime/zsr/stub.hpp
+++ b/runtime/zsr/stub.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
+#include "export.hpp"
 #include <vector>
 
 namespace zsr {
 
 struct Package;
 
-const std::vector<const Package*>& packages();
+ZSR_EXPORT const std::vector<const Package*>& packages();
 
 }

--- a/runtime/zsr/types.hpp
+++ b/runtime/zsr/types.hpp
@@ -12,13 +12,19 @@
 #include <string>
 #include <vector>
 
+#if _MSC_VER
+/* Disable warnings about unexported template instantiations */
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+
 namespace zsr {
 
 /**
  * Generic parameter list.
  * See `Parameter::set`.
  */
-struct ParameterList
+struct ZSR_EXPORT ParameterList
 {
     std::any list;
 };
@@ -32,7 +38,7 @@ struct ParameterList
  * Use information from CType for type detection/conversion.
  * The ZType does not have to match the CType.
  */
-struct ZType
+struct ZSR_EXPORT ZType
 {
     enum
     {
@@ -59,7 +65,7 @@ struct ZType
 /**
  * Generated C++ type information.
  */
-struct CType
+struct ZSR_EXPORT CType
 {
     enum
     {
@@ -76,7 +82,7 @@ struct CType
     bool array = false; /* Array (vector) of type */
 };
 
-struct TypeRef
+struct ZSR_EXPORT TypeRef
 {
     std::string package;
     std::string ident;
@@ -88,7 +94,7 @@ struct TypeRef
 /**
  * Subtype
  */
-struct SubType
+struct ZSR_EXPORT SubType
 {
     std::string ident;
     const TypeRef* type = nullptr;
@@ -97,7 +103,7 @@ struct SubType
 /**
  * Package constant
  */
-struct Constant
+struct ZSR_EXPORT Constant
 {
     std::string ident;
     Variant value;
@@ -107,7 +113,7 @@ struct Constant
 /**
  * Bitmask value
  */
-struct BitmaskValue
+struct ZSR_EXPORT BitmaskValue
 {
     std::string ident;
     Variant value;
@@ -116,7 +122,7 @@ struct BitmaskValue
 /**
  * Bitmask
  */
-struct Bitmask
+struct ZSR_EXPORT Bitmask
 {
     std::string ident;
     std::vector<const BitmaskValue*> values;
@@ -125,7 +131,7 @@ struct Bitmask
 /**
  * Enumeration item
  */
-struct EnumerationItem
+struct ZSR_EXPORT EnumerationItem
 {
     std::string ident;
     Variant value;
@@ -134,7 +140,7 @@ struct EnumerationItem
 /**
  * Enumeration
  */
-struct Enumeration
+struct ZSR_EXPORT Enumeration
 {
     std::string ident;
     std::vector<const EnumerationItem*> items;
@@ -143,7 +149,7 @@ struct Enumeration
 /**
  * Compound field/member
  */
-struct Field
+struct ZSR_EXPORT Field
 {
     std::string ident;
     const TypeRef* type = nullptr;
@@ -172,7 +178,7 @@ struct Field
 /**
  * Compound parameter
  */
-struct Parameter
+struct ZSR_EXPORT Parameter
 {
     std::string ident;
     const TypeRef* type = nullptr;
@@ -184,7 +190,7 @@ struct Parameter
 /**
  * Function
  */
-struct Function
+struct ZSR_EXPORT Function
 {
     std::string ident;
     const TypeRef* type = nullptr;
@@ -195,7 +201,7 @@ struct Function
 /**
  * Compound (Structure, Choice or Union)
  */
-struct Compound
+struct ZSR_EXPORT Compound
 {
     std::string ident;
     enum class Type {
@@ -265,7 +271,7 @@ struct Compound
 /**
  * Package
  */
-struct Package
+struct ZSR_EXPORT Package
 {
     std::string ident;
 
@@ -277,3 +283,7 @@ struct Package
 };
 
 } // namespace zsr
+
+#if _MSC_VER
+#pragma warning(pop)
+#endif

--- a/runtime/zsr/variant.hpp
+++ b/runtime/zsr/variant.hpp
@@ -13,6 +13,11 @@
 #include "zsr/introspectable.hpp"
 #include "zserio/BitBuffer.h"
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4251)
+#endif
+
 /**
  * List of types the variant stores (+ vectors of them).
  */
@@ -201,7 +206,7 @@ struct VariantCast<std::bitset<_N>, _Target>
 /**
  * Zsr value container.
  */
-class Variant final
+class ZSR_EXPORT Variant final
 {
 public:
     Variant()
@@ -295,5 +300,8 @@ auto visit(const zsr::Variant& v, _Fun& f)
 #undef GEN
 }
 
-
 } // namespace zsr
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif


### PR DESCRIPTION
Via `__declspec(...)` on Windows and `__attribute__ ((...))` on Linux/macOS.