### PR TITLE
Capture typedict by reference

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,7 +23,7 @@ jobs:
         mkdir build
     - name: Clone zserio
       run: |
-        git clone https://github.com/ndsev/zserio.git zserio
+        git clone -b v2.0.0-pre3 https://github.com/ndsev/zserio.git zserio
     - name: Configure
       working-directory: build
       run: >
@@ -56,7 +56,7 @@ jobs:
         mkdir build
     - name: Clone zserio
       run: |
-        git clone https://github.com/ndsev/zserio.git zserio
+        git clone -b v2.0.0-pre3 https://github.com/ndsev/zserio.git zserio
     - name: Configure
       working-directory: build
       run: >
@@ -93,7 +93,7 @@ jobs:
         brew install ant
     - name: Clone zserio
       run: |
-        git clone https://github.com/ndsev/zserio.git zserio
+        git clone -b v2.0.0-pre3 https://github.com/ndsev/zserio.git zserio
     - name: Configure
       working-directory: build
       run: >

--- a/runtime/src/parameterlist-helper.hpp
+++ b/runtime/src/parameterlist-helper.hpp
@@ -149,7 +149,7 @@ struct unpack_variant<std::vector<_Type>, true>
             std::transform(unpacked->begin(),
                            unpacked->end(),
                            std::back_inserter(casted),
-                           [t2c](const auto& i) {
+                           [&t2c](const auto& i) {
                                introspectable_cast<_Type>(i, t2c);
                            });
             return casted;

--- a/runtime/src/reflection-macros.hpp
+++ b/runtime/src/reflection-macros.hpp
@@ -256,7 +256,7 @@
                                                                         \
         auto args = std::any_cast<ParameterTupleType>(&params);         \
         if (args) {                                                     \
-            std::apply([&i, t2c](auto&&... vals) {                      \
+            std::apply([&i, &t2c](auto&&... vals) {                     \
                 zsr::introspectable_cast<CompoundType>(i, t2c)          \
                     .initialize(                                        \
                         zsr::parameterlist::deref_if_shared(vals)...);  \

--- a/runtime/test/zserio/structure_test/structure_test.cpp
+++ b/runtime/test/zserio/structure_test/structure_test.cpp
@@ -257,4 +257,20 @@ TEST(StructureTest, k_nested_compounds)
     }
 }
 
+TEST(StructureTest, l_later_registered_member_type)
+{
+    auto* meta_parent = zsr::find<zsr::Compound>(pkg, "l_parent");
+    auto* meta_field = zsr::find<zsr::Field>(*meta_parent, "a");
+
+    /* Alloc parent */
+    auto instance = meta_parent->alloc();
+
+    /* Access child instance */
+    auto member = meta_field->get(instance).get<zsr::Introspectable>();
+
+    ASSERT_TRUE(member);
+    ASSERT_TRUE(member->obj);
+    ASSERT_TRUE(member->meta());
+}
+
 } // namespace

--- a/runtime/test/zserio/structure_test/structure_test.zs
+++ b/runtime/test/zserio/structure_test/structure_test.zs
@@ -93,3 +93,13 @@ struct k_struct_a {
 struct k_struct_b {
     k_struct_a a[];
 };
+
+/** L - Lookup member type declared after parent type */
+
+struct l_parent {
+    l_member a;
+};
+
+struct l_member {
+    int32 a;
+};


### PR DESCRIPTION
Bug introduced with #31. Tests failed to lookup member types declared after the parent type.
Capture global type dict by reference in lambdas.