### PR TITLE
Allow compound types as function return type

### DIFF
--- a/runtime/src/reflection-macros.hpp
+++ b/runtime/src/reflection-macros.hpp
@@ -324,24 +324,25 @@
 #define ZSERIO_REFLECT_STRUCTURE_FIELD_END() \
     }
 
-#define ZSERIO_REFLECT_STRUCTURE_FUNCTION_BEGIN(NAME, FUNNAME)           \
-    {                                                                    \
-        using ReturnType =                                               \
-            std::decay_t<                                                \
-                std::remove_reference_t<                                 \
-                    decltype(((CompoundType*)0)-> FUNNAME ())>>;         \
-                                                                         \
-        zsr::Function& f = s.functions.emplace_back();                   \
-        f.ident = FUNCTION_IDENT(#NAME);                                 \
-                                                                         \
-        f.call = [&](const zsr::Introspectable& i) -> zsr::Variant {     \
-            return {                                                     \
-                zsr::introspectable_cast<CompoundType>(i, t2c)           \
-                    . FUNNAME ()                                         \
-            };                                                           \
-        };                                                               \
-                                                                         \
-        CUR_TYPE(f);                                                     \
+#define ZSERIO_REFLECT_STRUCTURE_FUNCTION_BEGIN(NAME, FUNNAME)          \
+    {                                                                   \
+        using ReturnType =                                              \
+            std::decay_t<                                               \
+                std::remove_reference_t<                                \
+                    decltype(((CompoundType*)0)-> FUNNAME ())>>;        \
+                                                                        \
+        zsr::Function& f = s.functions.emplace_back();                  \
+        f.ident = FUNCTION_IDENT(#NAME);                                \
+                                                                        \
+        f.call = [&](const zsr::Introspectable& i) -> zsr::Variant {    \
+            return zsr::variant_helper<ReturnType>::pack(               \
+                zsr::introspectable_cast<CompoundType>(i, t2c)          \
+                    . FUNNAME (),                                       \
+                t2c                                                     \
+            );                                                          \
+        };                                                              \
+                                                                        \
+        CUR_TYPE(f);                                                    \
         zsr::CTypeTraits<ReturnType>::set(tr.ctype);
 
 #define ZSERIO_REFLECT_STRUCTURE_FUNCTION_END() \

--- a/runtime/src/tmp-helper.hpp
+++ b/runtime/src/tmp-helper.hpp
@@ -41,4 +41,102 @@ shared_introspectable_cast(const zsr::Introspectable& i,
     return i.obj->as<_Compound>().obj;
 }
 
+template <class _Type, bool _IsCompound = is_compound<_Type>::value>
+struct variant_helper
+{
+    static _Type unpack(const Variant& v,
+                        const Type2Compound&)
+    {
+        if (auto unpacked = v.get<_Type>())
+            return *unpacked;
+
+        throw VariantCastError{};
+    }
+
+    static Variant pack(_Type v,
+                        const Type2Compound&)
+    {
+        return Variant{v};
+    }
+};
+
+template <class _Type>
+struct variant_helper<_Type, true>
+{
+    static _Type& unpack(Variant& v,
+                         const Type2Compound& t2c)
+    {
+        if (auto unpacked = v.get<Introspectable>()) {
+            return introspectable_cast<_Type>(*unpacked,
+                                              t2c);
+        }
+
+        throw VariantCastError{};
+    }
+
+    static const _Type& unpack(const Variant& v,
+                               const Type2Compound& t2c)
+    {
+        if (auto unpacked = v.get<Introspectable>()) {
+            return introspectable_cast<_Type>(*unpacked,
+                                              t2c);
+        }
+
+        throw VariantCastError{};
+    }
+
+    static Variant pack(_Type v,
+                        const Type2Compound& t2c)
+    {
+        auto iter = t2c.find(std::type_index(typeid(_Type)));
+        if (iter == t2c.end())
+            throw VariantCastError{};
+
+        Introspectable obj(Introspectable::FromObjectTag{},
+                           iter->second,
+                           std::move(v));
+
+        return Variant{std::move(obj)};
+    }
+};
+
+template <class _Type>
+struct variant_helper<std::vector<_Type>, true>
+{
+    static _Type unpack(const Variant& v,
+                        const Type2Compound& t2c)
+    {
+        if (auto unpacked = v.get<std::vector<Introspectable>>()) {
+            std::vector<_Type> casted;
+            casted.reserve(unpacked->size());
+
+            std::transform(unpacked->begin(),
+                           unpacked->end(),
+                           std::back_inserter(casted),
+                           [&t2c](const auto& i) {
+                               introspectable_cast<_Type>(i, t2c);
+                           });
+            return casted;
+        }
+
+        throw VariantCastError{};
+    }
+
+    static Variant pack(const std::vector<_Type>& v,
+                        const Type2Compound& t2c)
+    {
+        std::vector<Introspectable> values;
+        values.reserve(v.size());
+
+        std::transform(v.begin(), v.end(), std::back_inserter(values),
+                       [&](const auto& item) {
+                           return variant_helper<_Type>
+                               ::pack(item, t2c);
+                       });
+
+        return Variant{std::move(values)};
+    }
+};
+
+
 } // namespace zsr

--- a/runtime/test/zserio/structure_test/structure_test.zs
+++ b/runtime/test/zserio/structure_test/structure_test.zs
@@ -21,11 +21,21 @@ struct c_parameter_struct {
 struct c_struct(c_parameter_struct a) {};
 
 /**
- * D
+ * D - Reflect functions with various return types
  */
+struct d_res {
+    int32 a;
+};
+
 struct d_struct {
+    d_res a;
+
     function uint32 fun() {
         return 10;
+    }
+
+    function d_res fun2() {
+        return a;
     }
 };
 

--- a/runtime/zsr/introspectable-private.hpp
+++ b/runtime/zsr/introspectable-private.hpp
@@ -153,7 +153,17 @@ auto makeWeakInstance(const std::shared_ptr<InstanceBase>& master,
 template <class _T>
 auto makeUniqueInstance()
 {
-    return std::make_shared<Instance<_T>>(std::make_shared<_T>(), true);
+    return std::make_shared<Instance<_T>>(
+        std::make_shared<_T>(), true);
+}
+
+template <class _T>
+auto makeUniqueInstance(_T&& v)
+{
+    using Type = std::decay_t<_T>;
+
+    return std::make_shared<Instance<Type>>(
+        std::make_shared<Type>(std::forward<_T>(v)), true);
 }
 
 } // namespace impl

--- a/runtime/zsr/introspectable.hpp
+++ b/runtime/zsr/introspectable.hpp
@@ -24,6 +24,15 @@ struct Compound;
 class ZSR_EXPORT Introspectable
 {
 public:
+    struct FromObjectTag {};
+
+    template <class _Type>
+    Introspectable(FromObjectTag, const Compound* meta, _Type&& value)
+        : obj(impl::makeUniqueInstance(std::forward<_Type>(value)))
+    {
+        obj->meta = meta;
+    }
+
     Introspectable(const Compound*, std::shared_ptr<impl::InstanceBase>);
 
     Introspectable(const Introspectable&);


### PR DESCRIPTION
ZSerio supports a compound-type as function return-type.