### PR TITLE
add_zserio_module: Fix target compile options

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -154,13 +154,13 @@ function(add_zserio_module ZSR_MODULE_NAME)
     ${ZSR_MODULE_NAME})
 
   if (MSVC)
-    target_compile_options(${ZSR_MODULE_NAME}-reflection
+    target_compile_options(${ZSR_MODULE_NAME}
       PUBLIC
         /bigobj
         /EHsc
         /wd4100)
   else()
-    target_compile_options(${ZSR_MODULE_NAME}-reflection
+    target_compile_options(${ZSR_MODULE_NAME}
       PUBLIC
         -fPIC)
   endif()


### PR DESCRIPTION
Public target compile options must be set already for the original ZSR_MODULE_NAME.

### Review Checklist

- [x] The changes are understood.
- [x] The changes have been tested.
