### PR TITLE
Type check setter values

### DIFF
--- a/runtime/src/tmp-helper.hpp
+++ b/runtime/src/tmp-helper.hpp
@@ -10,10 +10,10 @@ void check_isa(const zsr::Introspectable& i,
 {
     auto iter = t2c.find(std::type_index(typeid(_Type)));
     if (iter == t2c.end())
-        throw zsr::IntrospectableCastError{nullptr, i.meta()};
+        throw zsr::IntrospectableCastError{i.meta(), nullptr};
 
     if (iter->second != i.meta() && i.meta())
-        throw zsr::IntrospectableCastError{iter->second, i.meta()};
+        throw zsr::IntrospectableCastError{i.meta(), iter->second};
 }
 
 template <class _Compound>

--- a/runtime/test/zserio/structure_test/structure_test.cpp
+++ b/runtime/test/zserio/structure_test/structure_test.cpp
@@ -331,4 +331,22 @@ TEST(StructureTest, m_field_type_info)
     ASSERT_EQ("M_child", meta_field_e->type->ident);
 }
 
+TEST(StructureTest, n_set_incompatible_type)
+{
+    auto* meta_parent = zsr::find<zsr::Compound>(pkg, "N_parent");
+    auto* meta_field = zsr::find<zsr::Field>(*meta_parent, "a");
+    auto* meta_wrong = zsr::find<zsr::Compound>(pkg, "N_wrong");
+
+    /* Alloc parent */
+    auto instance = meta_parent->alloc();
+
+    /* Alloc wrong member type */
+    auto wrong_instance = meta_wrong->alloc();
+
+    /* Set incompatible type. Expected N_expected, got N_wrong */
+    EXPECT_THROW(meta_field->set(instance, wrong_instance),
+                 zsr::IntrospectableCastError);
+}
+
+
 } // namespace

--- a/runtime/test/zserio/structure_test/structure_test.zs
+++ b/runtime/test/zserio/structure_test/structure_test.zs
@@ -128,3 +128,16 @@ struct M_parent {
     string d;
     M_child e;
 };
+
+/** N - Set incompatible instance to field */
+struct N_expected {
+    int32 a;
+};
+
+struct N_wrong {
+    int32 a;
+};
+
+struct N_parent {
+    N_expected a;
+};


### PR DESCRIPTION
### Changes

Replaced optimistic unpacking and casting `zsr::Introspectable` objects into a setters target type with calls to `introspectable_cast`.

### Steps to reproduce

Pass a `zsr::Introspectable` instance to a setter, that holds a type that can not be converted to the setters type.

### Review Checklist

<!-- Describe things a reviewer should do before approving the PR. -->

- [x] The changes are understood.
- [x] The changes are well documented.
- [x] The changes have been tested.
