### PR TITLE
Fix service-method request constness

### DIFF
--- a/runtime/src/reflection-macros.hpp
+++ b/runtime/src/reflection-macros.hpp
@@ -439,7 +439,7 @@
             1u, ArgTupleType>;                                          \
                                                                         \
         sm.call = [&t2c, &s, &sm](::zserio::IService& service,          \
-                                  zsr::Variant request)                 \
+                                  const zsr::Variant& request)          \
             -> zsr::Variant                                             \
         {                                                               \
             ServiceNamespace::Client client(service);                   \
@@ -447,8 +447,11 @@
                                                                         \
             zsr::ServiceMethod::Context ctx{s, sm, request};            \
                                                                         \
-            client. IDENT (zsr::variant_helper<RequestType>::unpack(    \
-                               request, t2c),                           \
+            /* Temporary copy because of zserio requiring non-const */  \
+            /* ref request object. */                                   \
+            auto unpackedRq = zsr::variant_helper<RequestType>::unpack( \
+                request, t2c);                                          \
+            client. IDENT (unpackedRq,                                  \
                            response,                                    \
                            &ctx);                                       \
                                                                         \

--- a/runtime/src/tmp-helper.hpp
+++ b/runtime/src/tmp-helper.hpp
@@ -1,6 +1,7 @@
 #include <type_traits>
 #include <typeindex>
 #include <unordered_map>
+#include <iterator>
 
 namespace zsr {
 

--- a/runtime/zsr/find.hpp
+++ b/runtime/zsr/find.hpp
@@ -43,6 +43,8 @@ DECL_ITER(Field,           Compound,    fields)
 DECL_ITER(Parameter,       Compound,    parameters)
 DECL_ITER(Function,        Compound,    functions)
 
+DECL_ITER(SubType,         Package,     subTypes)
+
 DECL_ITER(Service,         Package,     services)
 DECL_ITER(ServiceMethod,   Service,     methods)
 /* clang-format on */

--- a/runtime/zsr/types.hpp
+++ b/runtime/zsr/types.hpp
@@ -321,7 +321,7 @@ struct ZSR_EXPORT ServiceMethod
     TypeRef requestType;
     TypeRef responseType;
 
-    std::function<Variant(::zserio::IService&, Variant)> call;
+    std::function<Variant(::zserio::IService&, const Variant&)> call;
 
     /**
      * Object passed as user-data to zserio generated

--- a/runtime/zsr/variant.hpp
+++ b/runtime/zsr/variant.hpp
@@ -215,7 +215,7 @@ public:
     template <class _T>
     Variant(_T&& v)
     {
-        set<_T>(std::forward<_T>(v));
+        set(std::forward<_T>(v));
     }
 
     Variant(const Variant&) = default;


### PR DESCRIPTION
### Changes

Pass service-method request object by-const-ref instead of by-value.
Internally, zserio takes service-method request objects by non-const-ref.

### Steps to reproduce

Call a service method with a const request object.

### Review Checklist

- [ ] The changes are understood.
- [ ] The changes are well documented.
- [ ] The changes have been tested.
