### PR TITLE
Fix field optional detection

### DIFF
--- a/extension/src/zserio/emit/cpp_reflect/ReflectionEmitter.java
+++ b/extension/src/zserio/emit/cpp_reflect/ReflectionEmitter.java
@@ -118,7 +118,7 @@ public class ReflectionEmitter extends EmitterBase
         beginReflect("STRUCTURE_FIELD", args);
         reflectTypeInstantiation(field.getTypeInstantiation());
 
-        if (field.getOptionalClauseExpr() != null) {
+        if (field.isOptional()) {
             List<String> optArgs = Arrays.asList(new String[] {
                 hasName,
                 resetName


### PR DESCRIPTION
If a field is optional should be checked with `isOptional`.

### Changes

Optional fields without an optional expression where not emitted as optional fields.

### Review Checklist

- [ ] The changes are understood.
- [ ] The changes are well documented.
- [ ] The changes have been tested.
