### PR TITLE
Emit Array and Subtype typeref

### DIFF
--- a/extension/src/zserio/emit/cpp_reflect/ReflectionEmitter.java
+++ b/extension/src/zserio/emit/cpp_reflect/ReflectionEmitter.java
@@ -86,7 +86,7 @@ public class ReflectionEmitter extends EmitterBase
         });
 
         beginReflect("CONST", args);
-        reflectTypeInstantiation(constType.getTypeInstantiation(), false);
+        reflectTypeInstantiation(constType.getTypeInstantiation());
         endReflect("CONST");
     }
 
@@ -95,14 +95,9 @@ public class ReflectionEmitter extends EmitterBase
         type.getType().accept(new TypeRefVisitor(this, false));
     }
 
-    public void reflectTypeInstantiation(TypeInstantiation type, boolean inArray)
+    public void reflectTypeInstantiation(TypeInstantiation type)
     {
-        if (type instanceof ArrayInstantiation) {
-            this.reflectTypeInstantiation(
-                ((ArrayInstantiation)type).getElementTypeInstantiation(), true);
-        } else {
-            type.getType().accept(new TypeRefVisitor(this, inArray));
-        }
+        type.accept(new TypeRefVisitor(this, false));
     }
 
     public void reflectField(Field field)

--- a/extension/src/zserio/emit/cpp_reflect/ReflectionEmitter.java
+++ b/extension/src/zserio/emit/cpp_reflect/ReflectionEmitter.java
@@ -86,18 +86,23 @@ public class ReflectionEmitter extends EmitterBase
         });
 
         beginReflect("CONST", args);
-        reflectTypeInstantiation(constType.getTypeInstantiation());
+        reflectTypeInstantiation(constType.getTypeInstantiation(), false);
         endReflect("CONST");
     }
 
     public void reflectTypeReference(TypeReference type)
     {
-        type.getType().accept(new TypeRefVisitor(this));
+        type.getType().accept(new TypeRefVisitor(this, false));
     }
 
-    public void reflectTypeInstantiation(TypeInstantiation type)
+    public void reflectTypeInstantiation(TypeInstantiation type, boolean inArray)
     {
-        type.getType().accept(new TypeRefVisitor(this));
+        if (type instanceof ArrayInstantiation) {
+            this.reflectTypeInstantiation(
+                ((ArrayInstantiation)type).getElementTypeInstantiation(), true);
+        } else {
+            type.getType().accept(new TypeRefVisitor(this, inArray));
+        }
     }
 
     public void reflectField(Field field)
@@ -313,11 +318,11 @@ public class ReflectionEmitter extends EmitterBase
             }));
 
             beginReflect("SERVICE_METHOD_REQUEST", null);
-            method.getRequestType().accept(new TypeRefVisitor(this));
+            method.getRequestType().accept(new TypeRefVisitor(this, false));
             endReflect("SERVICE_METHOD_REQUEST");
 
             beginReflect("SERVICE_METHOD_RESPONSE", null);
-            method.getResponseType().accept(new TypeRefVisitor(this));
+            method.getResponseType().accept(new TypeRefVisitor(this, false));
             endReflect("SERVICE_METHOD_RESPONSE");
 
             endReflect("SERVICE_METHOD");

--- a/runtime/test/zserio/structure_test/structure_test.cpp
+++ b/runtime/test/zserio/structure_test/structure_test.cpp
@@ -348,5 +348,19 @@ TEST(StructureTest, n_set_incompatible_type)
                  zsr::IntrospectableCastError);
 }
 
+TEST(StructureTest, o_array_field)
+{
+    auto* meta_parent = zsr::find<zsr::Compound>(pkg, "O_parent");
+    auto* meta_field = zsr::find<zsr::Field>(*meta_parent, "a");
+
+    ASSERT_TRUE(meta_field);
+    ASSERT_TRUE(meta_field->type);
+
+    ASSERT_TRUE(meta_field->type->ztype.array);
+    ASSERT_EQ(meta_field->type->ztype.type, zsr::ZType::String);
+
+    ASSERT_TRUE(meta_field->type->ctype.array);
+    ASSERT_EQ(meta_field->type->ctype.type, zsr::CType::String);
+}
 
 } // namespace

--- a/runtime/test/zserio/structure_test/structure_test.zs
+++ b/runtime/test/zserio/structure_test/structure_test.zs
@@ -141,3 +141,8 @@ struct N_wrong {
 struct N_parent {
     N_expected a;
 };
+
+/** O - Array field type */
+struct O_parent {
+    string a[3];
+};


### PR DESCRIPTION
### Changes

* Emit type information for array-types
* Emit type information for subtype-types

### Affected use-cases

Type information stored in `zsr::TypeRef::ztype` is more precise.

### Review Checklist

- [x] The changes are understood.
- [x] The changes are well documented.
- [x] The changes have been tested.
