### PR TITLE
Store meta-type parent object reference

### DIFF
--- a/runtime/src/reflection-macros.hpp
+++ b/runtime/src/reflection-macros.hpp
@@ -67,7 +67,7 @@
 
 #define ZSERIO_REFLECT_SUBTYPE_BEGIN(NAME, PACKAGE, TYPE) \
     {                                                     \
-        zsr::SubType& t = p.subTypes.emplace_back();      \
+        zsr::SubType& t = p.subTypes.emplace_back(&p);    \
         t.ident = #NAME;                                  \
                                                           \
         CUR_TYPE(t);                                      \
@@ -86,18 +86,18 @@
  *   CONST_END
  */
 
-#define ZSERIO_REFLECT_CONST_BEGIN(NAME)               \
-    {                                                  \
-        using ConstType =                              \
-            std::decay_t<                              \
-                std::remove_const_t<                   \
-                    decltype(PkgNamespace:: NAME)>>;   \
-                                                       \
-        zsr::Constant& c = p.constants.emplace_back(); \
-        c.ident = #NAME;                               \
-        c.value.set(PkgNamespace:: NAME);              \
-                                                       \
-        CUR_TYPE(c);                                   \
+#define ZSERIO_REFLECT_CONST_BEGIN(NAME)                 \
+    {                                                    \
+        using ConstType =                                \
+            std::decay_t<                                \
+                std::remove_const_t<                     \
+                    decltype(PkgNamespace:: NAME)>>;     \
+                                                         \
+        zsr::Constant& c = p.constants.emplace_back(&p); \
+        c.ident = #NAME;                                 \
+        c.value.set(PkgNamespace:: NAME);                \
+                                                         \
+        CUR_TYPE(c);                                     \
         zsr::CTypeTraits<ConstType>::set(tr.ctype);
 
 #define ZSERIO_REFLECT_CONST_END()       \
@@ -140,7 +140,7 @@
     {                                                                \
         using CompoundType = PkgNamespace::NAME;                     \
                                                                      \
-        zsr::Compound& s = p.compounds.emplace_back();               \
+        zsr::Compound& s = p.compounds.emplace_back(&p);             \
         t2c[std::type_index(typeid(CompoundType))] =                 \
             &s;                                                      \
                                                                      \
@@ -224,12 +224,12 @@
             return obj.GETTER();                                               \
         };                                                                     \
                                                                                \
-        zsr::Parameter& param = s.parameters.emplace_back();                   \
+        zsr::Parameter& param = s.parameters.emplace_back(&s);                 \
         param.ident = PARAMETER_IDENT(#NAME);                                  \
                                                                                \
         param.set = GEN_INIT_PARAMETER_LIST_SET(IDX);                          \
                                                                                \
-        zsr::Field& f = s.fields.emplace_back();                               \
+        zsr::Field& f = s.fields.emplace_back(&s);                             \
         param.field = &f;                                                      \
         f.ident = FIELD_IDENT(#NAME);                                          \
                                                                                \
@@ -320,7 +320,7 @@
                 std::remove_reference_t<                              \
                     decltype(((CompoundType*)0)-> GETTER ())>>;       \
                                                                       \
-        zsr::Field& f = s.fields.emplace_back();                      \
+        zsr::Field& f = s.fields.emplace_back(&s);                    \
         f.ident = FIELD_IDENT(#NAME);                                 \
                                                                       \
         GEN_FIELD_ACCESSORS(GETTER, SETTER)                           \
@@ -338,7 +338,7 @@
                 std::remove_reference_t<                                \
                     decltype(((CompoundType*)0)-> FUNNAME ())>>;        \
                                                                         \
-        zsr::Function& f = s.functions.emplace_back();                  \
+        zsr::Function& f = s.functions.emplace_back(&s);                \
         f.ident = FUNCTION_IDENT(#NAME);                                \
                                                                         \
         f.call = [&](const zsr::Introspectable& i) -> zsr::Variant {    \
@@ -364,22 +364,22 @@
  *   ENUMERATION_END
  */
 
-#define ZSERIO_REFLECT_ENUMERATION_BEGIN(NAME)               \
-    {                                                        \
-        using EnumType =                                     \
-            PkgNamespace:: NAME ;                            \
-                                                             \
-        zsr::Enumeration& e = p.enumerations.emplace_back(); \
+#define ZSERIO_REFLECT_ENUMERATION_BEGIN(NAME)                 \
+    {                                                          \
+        using EnumType =                                       \
+            PkgNamespace:: NAME ;                              \
+                                                               \
+        zsr::Enumeration& e = p.enumerations.emplace_back(&p); \
         e.ident = #NAME;
 
 #define ZSERIO_REFLECT_ENUMERATION_END() \
     }
 
-#define ZSERIO_REFLECT_ENUMERATION_ITEM(NAME)              \
-    {                                                      \
-        zsr::EnumerationItem& ei = e.items.emplace_back(); \
-        ei.ident = #NAME;                                  \
-        ei.value.set(EnumType:: NAME);                     \
+#define ZSERIO_REFLECT_ENUMERATION_ITEM(NAME)                \
+    {                                                        \
+        zsr::EnumerationItem& ei = e.items.emplace_back(&e); \
+        ei.ident = #NAME;                                    \
+        ei.value.set(EnumType:: NAME);                       \
     }
 
 /**
@@ -391,22 +391,22 @@
  *   BITMASK_END
  */
 
-#define ZSERIO_REFLECT_BITMASK_BEGIN(NAME)           \
-    {                                                \
-        using BitmaskType =                          \
-            PkgNamespace:: NAME ;                    \
-                                                     \
-        zsr::Bitmask& b = p.bitmasks.emplace_back(); \
+#define ZSERIO_REFLECT_BITMASK_BEGIN(NAME)             \
+    {                                                  \
+        using BitmaskType =                            \
+            PkgNamespace:: NAME ;                      \
+                                                       \
+        zsr::Bitmask& b = p.bitmasks.emplace_back(&p); \
         b.ident = #NAME;
 
 #define ZSERIO_REFLECT_BITMASK_END() \
     }
 
-#define ZSERIO_REFLECT_BITMASK_VALUE(NAME)               \
-    {                                                    \
-        zsr::BitmaskValue& bv = b.values.emplace_back(); \
-        bv.ident = #NAME;                                \
-        bv.value.set(BitmaskType::Values:: NAME);        \
+#define ZSERIO_REFLECT_BITMASK_VALUE(NAME)                 \
+    {                                                      \
+        zsr::BitmaskValue& bv = b.values.emplace_back(&b); \
+        bv.ident = #NAME;                                  \
+        bv.value.set(BitmaskType::Values:: NAME);          \
     }
 
 /**
@@ -427,7 +427,7 @@
     {                                                       \
         namespace ServiceNamespace = PkgNamespace :: NAME ; \
                                                             \
-        auto& s = p.services.emplace_back();                \
+        auto& s = p.services.emplace_back(&p);              \
         s.ident = #NAME;
 
 #define ZSERIO_REFLECT_SERVICE_END()            \
@@ -435,7 +435,7 @@
 
 #define ZSERIO_REFLECT_SERVICE_METHOD_BEGIN(NAME, IDENT)                \
     {                                                                   \
-        auto& sm = s.methods.emplace_back();                            \
+        auto& sm = s.methods.emplace_back(&s);                          \
         sm.ident = FUNCTION_IDENT(#NAME);                               \
                                                                         \
         using ArgTupleType = zsr::argument_tuple_t<                     \

--- a/runtime/test/zserio/bitmask_test/bitmask_test.cpp
+++ b/runtime/test/zserio/bitmask_test/bitmask_test.cpp
@@ -8,6 +8,7 @@ TEST(BitmaskTest, check_bitmask_values) {
     auto* meta_bitmask = zsr::find<zsr::Bitmask>(pkg, "Mask");
 
     ASSERT_TRUE(meta_bitmask);
+    ASSERT_EQ(&meta_bitmask->parent, &pkg);
     ASSERT_EQ(meta_bitmask->values.size(), 3);
 
     auto ASSERT_VALUE = [&](auto ident, unsigned val) {
@@ -15,6 +16,7 @@ TEST(BitmaskTest, check_bitmask_values) {
             *meta_bitmask, ident);
 
         ASSERT_TRUE(meta_value);
+        ASSERT_EQ(&meta_value->parent, meta_bitmask);
         ASSERT_VARIANT_EQ(meta_value->value, val);
     };
 

--- a/runtime/test/zserio/enumeration_test/enumeration_test.cpp
+++ b/runtime/test/zserio/enumeration_test/enumeration_test.cpp
@@ -9,6 +9,7 @@ TEST(EnumTest, check_enum_items)
     auto* meta_enumeration = zsr::find<zsr::Enumeration>(pkg, "Enum");
 
     ASSERT_TRUE(meta_enumeration);
+    ASSERT_EQ(&meta_enumeration->parent, &pkg);
     ASSERT_EQ(meta_enumeration->items.size(), 3);
 
     auto ASSERT_ITEM = [&](auto ident, auto value) {
@@ -16,6 +17,7 @@ TEST(EnumTest, check_enum_items)
             *meta_enumeration, ident);
 
         ASSERT_TRUE(meta_item);
+        ASSERT_EQ(&meta_item->parent, meta_enumeration);
         ASSERT_VARIANT_EQ(meta_item->value, value);
     };
 

--- a/runtime/test/zserio/service_test/service_test.cpp
+++ b/runtime/test/zserio/service_test/service_test.cpp
@@ -7,9 +7,11 @@ PKG;
 TEST(ServiceTest, check_service_meta) {
     auto* a_service = zsr::find<zsr::Service>(pkg, "A_service");
     ASSERT_TRUE(a_service);
+    ASSERT_EQ(&a_service->parent, &pkg);
    
     auto* a_service_method_a = zsr::find<zsr::ServiceMethod>(*a_service, "method_a");
     ASSERT_TRUE(a_service_method_a);
+    ASSERT_EQ(&a_service_method_a->parent, a_service);
 }
 
 }

--- a/runtime/test/zserio/structure_test/structure_test.cpp
+++ b/runtime/test/zserio/structure_test/structure_test.cpp
@@ -9,6 +9,8 @@ TEST(StructureTest, a_alloc_empty)
     auto* meta_struct = zsr::find<zsr::Compound>(pkg, "A_struct");
 
     ASSERT_TRUE(meta_struct);
+    ASSERT_EQ(&meta_struct->parent, &pkg);
+
     ASSERT_TRUE(meta_struct->alloc);
     ASSERT_FALSE(meta_struct->initialize);
     ASSERT_EQ(meta_struct->type, zsr::Compound::Type::Structure);

--- a/runtime/zsr/types.hpp
+++ b/runtime/zsr/types.hpp
@@ -21,14 +21,28 @@
 #endif
 
 /* Delete copy & move operators */
-#define NOCOPY(TYPE)                            \
+#define META_TYPE_ROOT(TYPE)                    \
     TYPE() {};                                  \
     TYPE(const TYPE &) = delete;                \
     TYPE(TYPE &&) = delete;                     \
     TYPE& operator=(const TYPE &) = delete;     \
     TYPE& operator=(TYPE &&) = delete;
 
+#define META_TYPE(TYPE, PARENT)                 \
+    PARENT& parent;                             \
+    TYPE(PARENT* p) : parent(*p) {};            \
+    TYPE(const TYPE &) = delete;                \
+    TYPE(TYPE &&) = delete;                     \
+    TYPE& operator=(const TYPE &) = delete;     \
+    TYPE& operator=(TYPE &&) = delete;
+
 namespace zsr {
+
+struct Package;
+struct Bitmask;
+struct Enumeration;
+struct Compound;
+struct Service;
 
 /**
  * Generic parameter list.
@@ -106,7 +120,7 @@ struct ZSR_EXPORT TypeRef
  */
 struct ZSR_EXPORT SubType
 {
-    NOCOPY(SubType)
+    META_TYPE(SubType, Package)
 
     std::string ident;
     std::optional<TypeRef> type;
@@ -117,7 +131,7 @@ struct ZSR_EXPORT SubType
  */
 struct ZSR_EXPORT Constant
 {
-    NOCOPY(Constant)
+    META_TYPE(Constant, Package)
 
     std::string ident;
     Variant value;
@@ -129,7 +143,7 @@ struct ZSR_EXPORT Constant
  */
 struct ZSR_EXPORT BitmaskValue
 {
-    NOCOPY(BitmaskValue)
+    META_TYPE(BitmaskValue, Bitmask)
 
     std::string ident;
     Variant value;
@@ -140,7 +154,7 @@ struct ZSR_EXPORT BitmaskValue
  */
 struct ZSR_EXPORT Bitmask
 {
-    NOCOPY(Bitmask)
+    META_TYPE(Bitmask, Package)
 
     std::string ident;
     std::deque<BitmaskValue> values;
@@ -151,7 +165,7 @@ struct ZSR_EXPORT Bitmask
  */
 struct ZSR_EXPORT EnumerationItem
 {
-    NOCOPY(EnumerationItem)
+    META_TYPE(EnumerationItem, Enumeration)
 
     std::string ident;
     Variant value;
@@ -162,7 +176,7 @@ struct ZSR_EXPORT EnumerationItem
  */
 struct ZSR_EXPORT Enumeration
 {
-    NOCOPY(Enumeration)
+    META_TYPE(Enumeration, Package)
 
     std::string ident;
     std::deque<EnumerationItem> items;
@@ -173,7 +187,7 @@ struct ZSR_EXPORT Enumeration
  */
 struct ZSR_EXPORT Field
 {
-    NOCOPY(Field)
+    META_TYPE(Field, Compound)
 
     std::string ident;
     std::optional<TypeRef> type;
@@ -204,7 +218,7 @@ struct ZSR_EXPORT Field
  */
 struct ZSR_EXPORT Parameter
 {
-    NOCOPY(Parameter)
+    META_TYPE(Parameter, Compound)
 
     std::string ident;
     const TypeRef* type = nullptr;
@@ -218,7 +232,7 @@ struct ZSR_EXPORT Parameter
  */
 struct ZSR_EXPORT Function
 {
-    NOCOPY(Function)
+    META_TYPE(Function, Compound)
 
     std::string ident;
     std::optional<TypeRef> type;
@@ -231,7 +245,7 @@ struct ZSR_EXPORT Function
  */
 struct ZSR_EXPORT Compound
 {
-    NOCOPY(Compound)
+    META_TYPE(Compound, Package)
 
     std::string ident;
     enum class Type {
@@ -314,7 +328,7 @@ struct ZSR_EXPORT Compound
  */
 struct ZSR_EXPORT ServiceMethod
 {
-    NOCOPY(ServiceMethod)
+    META_TYPE(ServiceMethod, Service)
 
     std::string ident;
 
@@ -344,7 +358,7 @@ struct ZSR_EXPORT ServiceMethod
  */
 struct ZSR_EXPORT Service
 {
-    NOCOPY(Service)
+    META_TYPE(Service, Package)
 
     std::string ident;
     std::deque<ServiceMethod> methods;
@@ -355,7 +369,7 @@ struct ZSR_EXPORT Service
  */
 struct ZSR_EXPORT Package
 {
-    NOCOPY(Package)
+    META_TYPE_ROOT(Package)
 
     std::string ident;
 
@@ -368,6 +382,9 @@ struct ZSR_EXPORT Package
 };
 
 } // namespace zsr
+
+#undef META_TYPE_ROOT
+#undef META_TYPE
 
 #if _MSC_VER
 #pragma warning(pop)


### PR DESCRIPTION
### Changes

Store meta-type parent reference along with child objects.
E.g. `zsr::Compound` has a reference to its `zsr::Package`.

### Review Checklist

- [ ] The changes are understood.
- [ ] The changes are well documented.
- [ ] The changes have been tested.
