### PR TITLE
MSVC build fixes.

### DIFF
--- a/runtime/zsr/find.hpp
+++ b/runtime/zsr/find.hpp
@@ -20,7 +20,7 @@ struct ZSR_EXPORT child_iter<zsr::Package>
 
 #define DECL_ITER(TYPE, PARENT_TYPE, LIST)                                   \
     template <>                                                              \
-    struct ZSR_EXPORT child_iter<TYPE>                                       \
+    struct child_iter<TYPE>                                                  \
     {                                                                        \
         static auto get(const PARENT_TYPE& r)                                \
         {                                                                    \

--- a/runtime/zsr/variant.hpp
+++ b/runtime/zsr/variant.hpp
@@ -26,7 +26,6 @@
     _(int64_t)                                  \
     _(uint64_t)                                 \
     _(double)                                   \
-    _(bool)                                     \
     _(std::string)                              \
     _(zserio::BitBuffer)                        \
     _(zsr::Introspectable)


### PR DESCRIPTION
### Changes

* Some symbols were not exported on Windows.
* Removed unused bool variant.
