### PR TITLE
json: Serialize enums as objects

### DIFF
--- a/extension/freemarker/package.cpp.ftl
+++ b/extension/freemarker/package.cpp.ftl
@@ -25,23 +25,6 @@ using Type2Compound = std::unordered_map<std::type_index, const zsr::Compound*>;
 #pragma warning(disable:4100) /* Unreferenced parameter */
 #endif
 
-[[maybe_unused]]
-static auto identToSnake(const char* ident)
-{
-    std::string snake;
-    snake.reserve(strlen(ident) + 1);
-
-    auto wasLower = islower(*ident);
-    do {
-        if (isupper(*ident) && wasLower)
-            snake.push_back('_');
-        snake.push_back((char)tolower(*ident));
-        wasLower = islower(*ident);
-    } while (*++ident);
-
-    return snake;
-}
-
 <#list includes as include>
 #include "${include}"
 </#list>

--- a/runtime/src/introspectable-json.cpp
+++ b/runtime/src/introspectable-json.cpp
@@ -83,11 +83,14 @@ struct JsonVisitor
                 auto&& key = field.ident;
 
                 const auto isSet = !field.has || field.has(obj);
-                if (isSet)
-                    j[key] = JsonVisitor<zsr::Field>(&field, pkgs, opts)
-                        .visit(field.get(obj));
-                else
+                if (isSet) {
+                    try {
+                        j[key] = JsonVisitor<zsr::Field>(&field, pkgs, opts)
+                            .visit(field.get(obj));
+                    } catch (...) {}
+                } else {
                     j[key] = nullptr;
+                }
             }
         }
 
@@ -96,7 +99,9 @@ struct JsonVisitor
                 auto&& key = fun.ident;
                 auto&& value = fun.call(obj);
 
-                j[key] = JsonVisitor<zsr::Function>(&fun, pkgs, opts).visit(value);
+                try {
+                    j[key] = JsonVisitor<zsr::Function>(&fun, pkgs, opts).visit(value);
+                } catch (...) {}
             }
         }
 

--- a/runtime/src/introspectable-json.cpp
+++ b/runtime/src/introspectable-json.cpp
@@ -124,12 +124,16 @@ struct JsonVisitor
     {
         if (opts & zsr::SERIALIZE_RESOLVE_ENUM) {
             if (auto e = getType<zsr::Enumeration>(pkgs, context)) {
-                j = resolveEnum(*e, v);
-                return;
+                j = {
+                    {"ident", resolveEnum(*e, v)},
+                    {"value", v}
+                };
+            } else {
+                j = v;
             }
+        } else {
+            j = v;
         }
-
-        j = v;
     }
 
     template <class _Type>

--- a/runtime/src/reflection-macros.hpp
+++ b/runtime/src/reflection-macros.hpp
@@ -1,16 +1,5 @@
 /* clang-format off */
 
-#ifdef ZSR_PYTHONIC_IDENTIFIERS
-    #define FIELD_IDENT(x) (identToSnake(x))
-    #define PARAMETER_IDENT(x) (identToSnake(x))
-    #define FUNCTION_IDENT(x) (identToSnake(x))
-#else
-    #define FIELD_IDENT(x) (x)
-    #define PARAMETER_IDENT(x) (x)
-    #define FUNCTION_IDENT(x) (x)
-#endif
-
-
 /**
  * Expose the current objects `type` member for further
  * use by `ZSERIO_REFLECT_TYPE_REF`.
@@ -231,13 +220,13 @@
         };                                                                     \
                                                                                \
         zsr::Parameter& param = s.parameters.emplace_back(&s);                 \
-        param.ident = PARAMETER_IDENT(#NAME);                                  \
+        param.ident = #NAME;                                                   \
                                                                                \
         param.set = GEN_INIT_PARAMETER_LIST_SET(IDX);                          \
                                                                                \
         zsr::Field& f = s.fields.emplace_back(&s);                             \
         param.field = &f;                                                      \
-        f.ident = FIELD_IDENT(#NAME);                                          \
+        f.ident = #NAME;                                                       \
                                                                                \
         f.get = Helper::getFun<CompoundType>(fieldGetter, &f, t2c);            \
         f.set = {}; /* Read-only */                                            \
@@ -327,7 +316,7 @@
                     decltype(((CompoundType*)0)-> GETTER ())>>;       \
                                                                       \
         zsr::Field& f = s.fields.emplace_back(&s);                    \
-        f.ident = FIELD_IDENT(#NAME);                                 \
+        f.ident = #NAME;                                              \
                                                                       \
         GEN_FIELD_ACCESSORS(GETTER, SETTER)                           \
                                                                       \
@@ -345,7 +334,7 @@
                     decltype(((CompoundType*)0)-> FUNNAME ())>>;        \
                                                                         \
         zsr::Function& f = s.functions.emplace_back(&s);                \
-        f.ident = FUNCTION_IDENT(#NAME);                                \
+        f.ident = #NAME;                                                \
                                                                         \
         f.call = [&](const zsr::Introspectable& i) -> zsr::Variant {    \
             return zsr::variant_helper<ReturnType>::pack(               \
@@ -442,7 +431,7 @@
 #define ZSERIO_REFLECT_SERVICE_METHOD_BEGIN(NAME, IDENT)                \
     {                                                                   \
         auto& sm = s.methods.emplace_back(&s);                          \
-        sm.ident = FUNCTION_IDENT(#NAME);                               \
+        sm.ident = #NAME;                                               \
                                                                         \
         using ArgTupleType = zsr::argument_tuple_t<                     \
             decltype(&ServiceNamespace::Client:: IDENT)>;               \

--- a/runtime/zsr/introspectable-json.hpp
+++ b/runtime/zsr/introspectable-json.hpp
@@ -14,7 +14,7 @@ enum ZSR_EXPORT SerializationOptions
     SERIALIZE_TYPE =         1u << 0, /// Serialize TypeRef to '__type'
     SERIALIZE_METADATA =     1u << 1, /// Serialize Compound to '__meta' for compounds
     SERIALIZE_FUNCTIONS =    1u << 2, /// Serialize function return values
-    SERIALIZE_RESOLVE_ENUM = 1u << 3, /// Resolve enum values to key ident
+    SERIALIZE_RESOLVE_ENUM = 1u << 3, /// Serialize enum values to {ident, value} objects
     SERIALIZE_BITBUFFER =    1u << 4, /// Serialize bitbuffers as arrays
 };
 


### PR DESCRIPTION
### Changes

Serialize enum values as objects containing the enums ident and value, if specified.

Also drop camel- to snake-case feature.

### Review Checklist

<!-- Describe things a reviewer should do before approving the PR. -->

- [ ] The changes are understood.
- [ ] The changes are well documented.
- [ ] The changes have been tested.
