### PR TITLE
Build tests for non-submodule builds only

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -36,9 +36,9 @@ jobs:
       run: |
         cmake --build .
     - name: Run CTest
-      working-directory: build
+      working-directory: build/runtime
       run: |
-        ctest --verbose
+        ctest --verbose --no-tests=error
 
   build-windows:
     name: Windows
@@ -71,9 +71,9 @@ jobs:
         cmake --build .
       shell: cmd
     - name: Run CTest
-      working-directory: build
+      working-directory: build/runtime
       run: |
-        ctest -C Debug --verbose
+        ctest -C Debug --verbose --no-tests=error
       shell: cmd
 
   build-macos:
@@ -107,6 +107,6 @@ jobs:
       run: |
         cmake --build .
     - name: Run CTest
-      working-directory: build
+      working-directory: build/runtime
       run: |
-        ctest -C Debug --verbose
+        ctest -C Debug --verbose --no-tests=error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.0.2)
-project(zserio-cpp-introspection)
 
-enable_testing()
+if (NOT DEFINED PROJECT_NAME)
+  project(zsr)
+
+  set(NOT_SUBPROJECT ON)
+  set(ZSR_BUILD_TESTS ON)
+endif()
 
 add_subdirectory(extension)
 add_subdirectory(runtime)

--- a/README
+++ b/README
@@ -22,4 +22,4 @@ Build
 Test
 ====
 
-> ctest --verbose
+> cd runtime && ctest --verbose

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0.2)
-project(zserio-cpp-introspection-extension)
+project(zsr-extension)
 
 find_program(ANT_PATH NAMES ant)
 if (NOT ANT_PATH)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10.2)
-project(zserio-cpp-introspection-runtime)
+project(zsr-runtime)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set(gtest_force_shared_crt ON CACHE BOOL "Always use msvcrt.dll")
@@ -296,14 +296,12 @@ function(add_zsr_module_test NAME)
     PRIVATE zs-${NAME} zs-${NAME}-reflection)
 endfunction()
 
-# Enable tests by default
-if (NOT DEFINED ZSR_ENABLE_TESTING)
-  set(ZSR_ENABLE_TESTING On)
-endif()
-
-if (ZSR_ENABLE_TESTING)
-  add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/googletest/googletest")
+if (ZSR_BUILD_TESTS)
   enable_testing()
+
+  if (NOT TARGET gtest)
+    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/googletest/googletest")
+  endif()
 
   add_zsr_test(variant-test "${TEST}/variant-test.cpp")
 

--- a/runtime/src/reflection-macros.hpp
+++ b/runtime/src/reflection-macros.hpp
@@ -17,12 +17,6 @@
         tr.ztype.array = IS_ARRAY;                                         \
     }
 
-
-/* C does not expand symbols used with # or ##
- * so we need to use this common workaround. */
-#define UID2(prefix, x) prefix ## x
-#define UID(prefix, x) UID2(prefix, x)
-
 /**
  * Package
  *


### PR DESCRIPTION
### Changes
* Disable building tests if built as submodule.
* Add gtest target only if not existing.
* Let ctest fail if no tests where found.
* Remove unused macros.

### Review Checklist

- [ ] The changes are understood.
- [ ] The changes are well documented.
- [ ] The changes have been tested.
