### PR TITLE
Add support for nested zsr::find operations

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build-linux:
@@ -13,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: true
+        submodules: recursive
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
@@ -46,7 +42,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: true
+        submodules: recursive
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
@@ -82,7 +78,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: true
+        submodules: recursive
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
@@ -99,7 +95,7 @@ jobs:
       run: >
         cmake
         -DCMAKE_BUILD_TYPE=Debug
-        -DCMAKE_CXX_STANDARD=11
+        -DCMAKE_CXX_STANDARD=17
         -DZSERIO_RT_DIR=../zserio/compiler/extensions/cpp/runtime/src
         ..
     - name: Build runtime

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "runtime/3rdparty/googletest"]
 	path = runtime/3rdparty/googletest
 	url = https://github.com/google/googletest.git
-[submodule "runtime/3rdparty/nlohmann_json"]
-	path = runtime/3rdparty/nlohmann_json
-	url = https://github.com/nlohmann/json.git
+[submodule "runtime/3rdparty/stx"]
+	path = runtime/3rdparty/stx
+	url = https://github.com/klebert-engineering/stx.git

--- a/README
+++ b/README
@@ -16,7 +16,7 @@ Build
 =====
 
 > mkdir build && cd build
-> cmake -DZSERIO_RT_DIR=<path-to-zserio-cpp-rt-dir> ..
+> cmake -DZSERIO_RT_DIR=<path/to/zserio/compiler/extensions/cpp/runtime/src> ..
 > cmake --build .
 
 Test

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -4,8 +4,7 @@ project(zsr-runtime)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set(gtest_force_shared_crt ON CACHE BOOL "Always use msvcrt.dll")
 
-set(SRC  "${CMAKE_CURRENT_SOURCE_DIR}")
-set(TEST "${SRC}/test")
+set(TEST "${CMAKE_CURRENT_SOURCE_DIR}/test")
 
 define_property(GLOBAL PROPERTY ZSERIO_DEPENDS_PY
     BRIEF_DOCS "Zserio dependency grepper."
@@ -15,6 +14,13 @@ set_property(GLOBAL PROPERTY ZSERIO_DEPENDS_PY "${CMAKE_CURRENT_SOURCE_DIR}/subm
 if (NOT MSVC)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON) # This does not set -fPIC :(
   set(CMAKE_CXX_FLAGS -fPIC)
+endif()
+
+## STX (standard library utilities)
+####
+
+if (NOT TARGET stx)
+  add_subdirectory(3rdparty/stx)
 endif()
 
 ## ZSERIO C++ runtime (optional)
@@ -33,12 +39,25 @@ endif()
 ####
 
 add_library(zsr SHARED
-  "${SRC}/src/types.cpp"
-  "${SRC}/src/types-json.cpp"
-  "${SRC}/src/error.cpp"
-  "${SRC}/src/introspectable.cpp"
-  "${SRC}/src/introspectable-json.cpp"
-  "${SRC}/src/speedy-j.cpp")
+  src/types.cpp
+  src/types-json.cpp
+  src/error.cpp
+  src/introspectable.cpp
+  src/introspectable-json.cpp
+  src/speedy-j.cpp
+
+  zsr/error.hpp
+  zsr/export.hpp
+  zsr/find.hpp
+  zsr/introspectable.hpp
+  zsr/introspectable-json.hpp
+  zsr/introspectable-private.hpp
+  zsr/reflection-main.hpp
+  zsr/speedy-j.hpp
+  zsr/speedy-j-impl.hpp
+  zsr/types.hpp
+  zsr/types-json.hpp
+  zsr/variant.hpp)
 
 target_compile_features(zsr
   PUBLIC cxx_std_17)
@@ -49,7 +68,7 @@ target_include_directories(zsr
 
 target_link_libraries(zsr
   PUBLIC
-    ZserioCppRuntime)
+    ZserioCppRuntime stx)
 
 set_target_properties(zsr
   PROPERTIES

--- a/runtime/test/zserio/find_test/find_test.cpp
+++ b/runtime/test/zserio/find_test/find_test.cpp
@@ -23,4 +23,21 @@ TEST(FindTest, resolve_type)
     ASSERT_EQ(meta_struct_a, resolved_b_a);
 }
 
+TEST(FindTest, recursive)
+{
+    auto resolved_b_a = zsr::find<zsr::Field>(zsr::packages(), "find_test.B_struct.a");
+    ASSERT_TRUE(resolved_b_a);
+    ASSERT_EQ(resolved_b_a->ident, "a");
+
+    auto unresolved_nested_service_method = zsr::find<zsr::ServiceMethod>(
+        zsr::packages(),
+        "find_test.nested_schema.child");
+    ASSERT_FALSE(unresolved_nested_service_method);
+
+    auto resolved_nested_service_method = zsr::find<zsr::ServiceMethod>(
+        zsr::packages(),
+        "nested_schema.child.X_service.serviceMethod");
+    ASSERT_TRUE(resolved_nested_service_method);
+}
+
 }

--- a/runtime/test/zserio/find_test/find_test.cpp
+++ b/runtime/test/zserio/find_test/find_test.cpp
@@ -40,4 +40,17 @@ TEST(FindTest, recursive)
     ASSERT_TRUE(resolved_nested_service_method);
 }
 
+TEST(FindTest, recursive_fail)
+{
+    /* Path is empty */ {
+        auto resolved = zsr::find<zsr::Field>(zsr::packages(), "");
+        ASSERT_FALSE(resolved);
+    }
+
+    /* Package name is missing */ {
+        auto resolved = zsr::find<zsr::Field>(zsr::packages(), "B_struct.a");
+        ASSERT_FALSE(resolved);
+    }
+}
+
 }

--- a/runtime/test/zserio/find_test/find_test.zs
+++ b/runtime/test/zserio/find_test/find_test.zs
@@ -1,5 +1,7 @@
 package find_test;
 
+import nested_schema.child.*;
+
 /**
  * A
  */

--- a/runtime/test/zserio/find_test/nested_schema/child.zs
+++ b/runtime/test/zserio/find_test/nested_schema/child.zs
@@ -1,0 +1,9 @@
+package nested_schema.child;
+
+struct RequestResponse {
+    int32 x;
+};
+
+service X_service {
+    RequestResponse serviceMethod(RequestResponse);
+};


### PR DESCRIPTION
### Changes

The zsr::find function can now take dot-separated identifier paths, which are resolved recursively.

### Review Checklist

- [x] The changes are understood.
- [x] The changes are well documented.
- [x] The changes have been tested.
