### PR TITLE
Visit call visitor for empty variant

### DIFF
--- a/runtime/src/introspectable-json.cpp
+++ b/runtime/src/introspectable-json.cpp
@@ -90,6 +90,10 @@ struct JsonVisitor
     }
 
     /* Visitor functions */
+    void operator()()
+    {
+        /* Empty variant */
+    }
 
     void operator()(const zsr::Introspectable& obj)
     {

--- a/runtime/zsr/variant.hpp
+++ b/runtime/zsr/variant.hpp
@@ -291,7 +291,7 @@ private:
 /**
  * Function for visiting variant values.
  *
- * _Fun must implement ()(T) and ()(std::vector<T>).
+ * _Fun must implement ()(T) and ()(std::vector<T>) and ()(void).
  */
 template <class _Fun>
 auto visit(const zsr::Variant& v, _Fun& f)
@@ -306,6 +306,7 @@ auto visit(const zsr::Variant& v, _Fun& f)
 
     ZSR_VARIANT_TYPES(GEN)
 
+    return f(); /* Fallback: empty variant */
 #undef GEN
 }
 


### PR DESCRIPTION
### Changes

Using `zsr::visit(…)` with a visitor which `operator()`s have a return type, lead to a warning about not returning a value in the case of an empty `zsr::Variant`.

Solution: Require the visitor to be callable with no arguments → empty variant.

### Review Checklist

<!-- Describe things a reviewer should do before approving the PR. -->

- [ ] The changes are understood.
- [ ] The changes are well documented.
- [ ] The changes have been tested.
