### PR TITLE
Replace `replace_with` with `stx::format`

### DIFF
--- a/runtime/src/error.cpp
+++ b/runtime/src/error.cpp
@@ -1,6 +1,7 @@
 #include "zsr/error.hpp"
 #include "zsr/types.hpp"
-#include "stx/string.h"
+
+#include "stx/format.h"
 
 namespace zsr {
 
@@ -21,32 +22,34 @@ ParameterListTypeError ParameterListTypeError::listEmpty()
 ParameterListTypeError ParameterListTypeError::listTypeMissmatch(const std::string& expected,
                                                                  const std::string& got)
 {
-    return ParameterListTypeError(stx::replace_with(
-        "Parameter list type error. Expected '?', got '?'", "?", expected, got));
+    return ParameterListTypeError(stx::format(
+        "Parameter list type error; expected '{}', got '{}'", expected, got));
 }
 
-IntrospectableCastError::IntrospectableCastError() : Error("Introspectable cast error")
+IntrospectableCastError::IntrospectableCastError()
+    : Error("Introspectable cast error")
 {}
 
 IntrospectableCastError::IntrospectableCastError(const Compound* isa,
                                                  const Compound* target)
-    : Error(stx::replace_with("Introspectable cast error from '?' to '?'", "?",
-                              isa ? isa->ident.c_str() : "<null>",
-                              target ? target->ident.c_str() : "<null>"))
+    : Error(stx::format("Introspectable cast error from '{}' to '{}'",
+                        isa ? isa->ident.c_str() : "<null>",
+                        target ? target->ident.c_str() : "<null>"))
 {}
 
-VariantCastError::VariantCastError() : Error("Variant cast error")
+VariantCastError::VariantCastError()
+    : Error("Variant cast error")
 {}
 
 UnknownIdentifierError::UnknownIdentifierError(std::string type,
                                                std::string ident)
-    : Error(stx::replace_with("Could not find ? '?'", "?", type, ident))
+    : Error(stx::format("Could not find '{}::{}'", type, ident))
     , type(std::move(type))
     , ident(std::move(ident))
 {}
 
 ParameterizedStructNotAllowedError::ParameterizedStructNotAllowedError(std::string_view ident)
-    : Error(stx::replace_with("Refusing to construct ? without parameters.", "?", ident))
+    : Error(stx::format("Refusing to construct '{}' without parameters.", ident))
 {}
 
 }


### PR DESCRIPTION
### Changes

Replaced `stx::replace_with` with new and shiny `stx::format`.

### Review Checklist

<!-- Describe things a reviewer should do before approving the PR. -->

- [x] The changes are understood.
- [x] The changes are well documented.
- [x] The changes have been tested.
