### PR TITLE
Fix JSON uchar (\uXXXX) encoding

### DIFF
--- a/runtime/src/speedy-j.cpp
+++ b/runtime/src/speedy-j.cpp
@@ -1,5 +1,7 @@
 #include <zsr/speedy-j.hpp>
 
+#include <limits>
+
 namespace speedyj
 {
 
@@ -41,11 +43,12 @@ static std::string jsonEncoded(const std::string& s)
             break;
 
         default:
-            if (c < ' ') {
+            if (c < ' ' || c > std::numeric_limits<signed char>::max()) {
                 /* Not optimal for multibyte codepoints, but
                  * it should work. */
                 char uliteral[7] = {0};
-                snprintf(uliteral, sizeof(uliteral), "\\u%04d", (int)c);
+                snprintf(uliteral, sizeof(uliteral), "\\u%04X",
+                         (unsigned)(c < 0 ? std::numeric_limits<unsigned char>::max() + 1u + c : c));
                 res += uliteral;
             } else {
                 res.push_back(c);

--- a/runtime/test/zserio/json_test/json_test.cpp
+++ b/runtime/test/zserio/json_test/json_test.cpp
@@ -47,6 +47,16 @@ TEST(JsonTest, json_string_escaping)
     ASSERT_EQ(ss.str(), "{\"\\\"hello\\\"\":\"\\\\world\\\\\"}");
 }
 
+TEST(JsonTest, json_uchar_string_escaping)
+{
+    speedyj::Stream ss;
+    ss << speedyj::Object
+       << "\"hello\x02\"" << "\\\xC2\xB9\\"
+       << speedyj::End;
+
+    ASSERT_EQ(ss.str(), "{\"\\\"hello\\u0002\\\"\":\"\\\\\\u00C2\\u00B9\\\\\"}");
+}
+
 TEST(JsonTest, serialize_meta_subtype)
 {
     speedyj::Stream ss;


### PR DESCRIPTION
### Changes

* Fixes conversion for signed chars.
* Corrects printf specifier to output hex digits (ouch…).


### Review Checklist

- [x] The changes are understood.
- [ ] The changes are well documented.
- [ ] The changes have been tested.
