### PR TITLE
SpeedyJ is now a separate target.

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -35,6 +35,35 @@ if (NOT TARGET ZserioCppRuntime)
   endif()
 endif()
 
+## SpeedyJ
+####
+
+add_library(speedyj SHARED
+  src/speedy-j.cpp
+  zsr/speedy-j.hpp
+  zsr/speedy-j-impl.hpp
+  )
+
+target_compile_features(speedyj
+  PUBLIC cxx_std_17)
+
+target_include_directories(speedyj
+  PUBLIC
+    "${SRC}")
+
+set_target_properties(speedyj
+  PROPERTIES
+    src_dir "${CMAKE_CURRENT_SOURCE_DIR}")
+
+target_compile_definitions(speedyj
+  PRIVATE
+    SPEEDYJ_BUILD=1)
+
+target_compile_options(speedyj
+  PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -fvisibility=hidden>)
+
 ## ZSR Runtime
 ####
 
@@ -44,7 +73,6 @@ add_library(zsr SHARED
   src/error.cpp
   src/introspectable.cpp
   src/introspectable-json.cpp
-  src/speedy-j.cpp
   src/getset.cpp
 
   zsr/error.hpp
@@ -55,8 +83,6 @@ add_library(zsr SHARED
   zsr/introspectable-private.hpp
   zsr/getset.hpp
   zsr/reflection-main.hpp
-  zsr/speedy-j.hpp
-  zsr/speedy-j-impl.hpp
   zsr/types.hpp
   zsr/types-json.hpp
   zsr/variant.hpp)
@@ -70,7 +96,7 @@ target_include_directories(zsr
 
 target_link_libraries(zsr
   PUBLIC
-    ZserioCppRuntime stx)
+    speedyj ZserioCppRuntime stx)
 
 set_target_properties(zsr
   PROPERTIES

--- a/runtime/zsr/speedy-j.hpp
+++ b/runtime/zsr/speedy-j.hpp
@@ -1,5 +1,15 @@
 #pragma once
 
+#if defined(_MSC_VER)
+    #if defined(SPEEDYJ_BUILD)
+        #define SPEEDYJ_EXPORT __declspec(dllexport)
+    #else
+        #define SPEEDYJ_EXPORT __declspec(dllimport)
+    #endif
+#else
+    #define SPEEDYJ_EXPORT __attribute__ ((visibility ("default")))
+#endif
+
 #include "export.hpp"
 
 #include <string>
@@ -13,7 +23,7 @@ namespace speedyj
 
 struct Error : public std::runtime_error
 {
-    ZSR_EXPORT Error(const char*);
+    SPEEDYJ_EXPORT Error(const char*);
 };
 
 /**
@@ -27,7 +37,7 @@ struct StreamState
     } type {Object};
     int itemIdx {0};
 
-    ZSR_EXPORT StreamState(Type);
+    SPEEDYJ_EXPORT StreamState(Type);
 };
 
 /**
@@ -37,8 +47,8 @@ struct StreamState
 class Stream
 {
 public:
-    ZSR_EXPORT Stream(Stream&&) = default;
-    ZSR_EXPORT Stream& operator=(Stream&&) = default;
+    SPEEDYJ_EXPORT Stream(Stream&&) = default;
+    SPEEDYJ_EXPORT Stream& operator=(Stream&&) = default;
 
     /**
      * Create an empty json stream.
@@ -46,24 +56,24 @@ public:
      * Note: Push either Object or Array first, otherwise
      *       pushing values will throw.
      */
-    ZSR_EXPORT Stream();
+    SPEEDYJ_EXPORT Stream();
 
     /**
      * Returns the streams string value.
      */
-    ZSR_EXPORT std::string str() const;
+    SPEEDYJ_EXPORT std::string str() const;
 
     /**
      * Push next value. Use operator << implementation.
      */
-    ZSR_EXPORT Stream& push(const std::string&);
-    ZSR_EXPORT Stream& push(unsigned long long);
-    ZSR_EXPORT Stream& push(unsigned long);
-    ZSR_EXPORT Stream& push(unsigned int);
-    ZSR_EXPORT Stream& push(long long);
-    ZSR_EXPORT Stream& push(long);
-    ZSR_EXPORT Stream& push(int);
-    ZSR_EXPORT Stream& push(double);
+    SPEEDYJ_EXPORT Stream& push(const std::string&);
+    SPEEDYJ_EXPORT Stream& push(unsigned long long);
+    SPEEDYJ_EXPORT Stream& push(unsigned long);
+    SPEEDYJ_EXPORT Stream& push(unsigned int);
+    SPEEDYJ_EXPORT Stream& push(long long);
+    SPEEDYJ_EXPORT Stream& push(long);
+    SPEEDYJ_EXPORT Stream& push(int);
+    SPEEDYJ_EXPORT Stream& push(double);
 
 /* private */
     std::stringstream ss_;
@@ -94,12 +104,12 @@ static constexpr struct Array_ {} Array;
 static constexpr struct Object_ {} Object;
 static constexpr struct End_ {} End;
 
-ZSR_EXPORT Stream& operator<<(Stream&, const Null_&);
-ZSR_EXPORT Stream& operator<<(Stream&, const True_&);
-ZSR_EXPORT Stream& operator<<(Stream&, const False_&);
-ZSR_EXPORT Stream& operator<<(Stream&, const Array_&);
-ZSR_EXPORT Stream& operator<<(Stream&, const Object_&);
-ZSR_EXPORT Stream& operator<<(Stream&, const End_&);
+SPEEDYJ_EXPORT Stream& operator<<(Stream&, const Null_&);
+SPEEDYJ_EXPORT Stream& operator<<(Stream&, const True_&);
+SPEEDYJ_EXPORT Stream& operator<<(Stream&, const False_&);
+SPEEDYJ_EXPORT Stream& operator<<(Stream&, const Array_&);
+SPEEDYJ_EXPORT Stream& operator<<(Stream&, const Object_&);
+SPEEDYJ_EXPORT Stream& operator<<(Stream&, const End_&);
 
 struct ScopedObject
 {


### PR DESCRIPTION
### Changes

You can now link to `speedyj` separately from zsr.