### PR TITLE
Use CMake 3.20.0 to fix error: property SOURCE_DIR not allowed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT DEFINED PROJECT_NAME)
   project(zsr)


### PR DESCRIPTION
### Changes

CMake build would fail with some older versions:
```
CMake Error at runtime/CMakeLists.txt:32 (get_target_property):
  INTERFACE_LIBRARY targets may only have whitelisted properties.  The
  property "SOURCE_DIR" is not allowed.
```
The new required CMake version includes a bugfix that resolves the issue. 

### Review Checklist

<!-- Describe things a reviewer should do before approving the PR. -->

- [x] The changes are understood.
- [x] The changes have been tested.
